### PR TITLE
Add portfolio favicon

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#171717"/>
+  <circle cx="50" cy="14" r="7" fill="#d8ff3e"/>
+  <path d="M13 22h20c7 0 11 3 11 9 0 5-3 8-8 9l10 11H35l-8-10h-4v10H13V22Zm10 8v5h9c2 0 3-1 3-3s-1-2-3-2h-9Z" fill="#f4f1e8"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:image" content="assets/projects/tt16.jpg" />
     <title>宋品豪 · AI Product Builder</title>
+    <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## What changed
- add an SPH favicon matching the portfolio visual system
- remove the browser's missing favicon request

## Validation
- asset exists and is referenced from `index.html`
- `git diff --check`