### PR TITLE
Restore README layout with correct project image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,102 +14,109 @@
 
 <br />
 
-## 你好，我是宋品豪 👋
-
-北京理工大学电子信息工程专业本科生，也是一名 **AI 原生产品开发者**。我把 Agent、叙事系统、生成式内容和交互设计装进真正能打开、能试玩、能分享的产品里。
-
-我偏爱从一个可以亲手玩的原型开始：先找到最小但完整的体验，再把数据、模型与工程系统逐层接上。目标不是做一张漂亮的概念图，而是让真实用户在一个链接里完成一次体验。
-
-> **NOW / 2026**　AI Agent 与 LLM 应用 · 互动叙事与生成式体验 · 像素世界与多模态内容 · 从原型到上线的工程闭环
+<table>
+  <tr>
+    <td width="62%" valign="top">
+      <h2>你好，我是宋品豪 👋</h2>
+      <p>
+        北京理工大学电子信息工程专业本科生，也是一名 <b>AI 原生产品开发者</b>。
+        我把 Agent、叙事系统、生成式内容和交互设计装进真正能打开、能试玩、能分享的产品里。
+      </p>
+      <p>
+        我偏爱从一个可以亲手玩的原型开始：先找到最小但完整的体验，再把数据、模型与工程系统逐层接上。
+        目标不是做一张漂亮的概念图，而是让真实用户在一个链接里完成一次体验。
+      </p>
+    </td>
+    <td width="38%" valign="top">
+      <h3>NOW / 2026</h3>
+      <ul>
+        <li>AI Agent 与 LLM 应用</li>
+        <li>互动叙事与生成式体验</li>
+        <li>像素世界与多模态内容</li>
+        <li>从原型到上线的工程闭环</li>
+      </ul>
+    </td>
+  </tr>
+</table>
 
 <br />
 
 ## Selected Work · 精选作品
 
-六个近期项目，五个可以直接在线体验。点击图片进入 Demo，点击项目名查看源码与完整说明。
+<p>六个近期项目，五个可以直接在线体验。点击图片进入 Demo，点击项目名查看源码与完整说明。</p>
 
-### 01 · [TT16 交易人格十六型](https://github.com/wzxsph/TT16) ↗
-
-<a href="https://wzxsph.github.io/TT16/"><img src="./assets/projects/tt16.jpg" width="100%" alt="TT16 交易人格十六型" /></a>
-
-用 20 个真实决策情境，把交易偏好整理成 16 种可复盘的人格地图。完整报告在浏览器本地生成。
-
-`React 19`　`TypeScript`　`Vite`　`Cloudflare`
-
-<a href="https://wzxsph.github.io/TT16/"><img alt="Live Demo" src="https://img.shields.io/badge/LIVE_DEMO-打开体验-D8FF3E?style=flat-square&labelColor=171717" /></a>
-
----
-
-### 02 · [BadGuard 散户看盘小纸条](https://github.com/wzxsph/BadGuard) ↗
-
-<a href="https://wzxsph.github.io/BadGuard/"><img src="./assets/projects/badguard.svg" width="100%" alt="BadGuard 散户看盘小纸条" /></a>
-
-每天收盘后，把 A 股常见技术状态整理成四张可解释的小纸条。只写观察与谨慎，不输出交易指令。
-
-`Cloudflare Workers`　`Python`　`AkShare`
-
-<a href="https://wzxsph.github.io/BadGuard/"><img alt="Pages Demo" src="https://img.shields.io/badge/PAGES_DEMO-静态体验-D8FF3E?style=flat-square&labelColor=171717" /></a>
-<a href="https://badguard.nizabentley397.workers.dev"><img alt="Realtime" src="https://img.shields.io/badge/LIVE_DATA-实时版-FF5B35?style=flat-square&labelColor=171717" /></a>
-
----
-
-### 03 · [Hip 24-Point Annotation Tool](https://github.com/wzxsph/hip-22-annotation-tool) ↗
-
-<a href="https://github.com/wzxsph/hip-22-annotation-tool"><img src="./assets/projects/hip22.png" width="100%" alt="Hip 24-Point Annotation Tool 工作区" /></a>
-
-面向髋关节 X 光片的本地标注与复核工具，支持 DICOM、YOLO 辅助初始化、24 个关键点和进度管理。
-
-`FastAPI`　`Canvas`　`YOLO`　`DICOM`
-
-<img alt="Source Only" src="https://img.shields.io/badge/SOURCE_ONLY-本地研究工具-F4F1E8?style=flat-square&labelColor=171717" />
-
----
-
-### 04 · [Narrative Trace](https://github.com/wzxsph/Narrative-Trace) ↗
-
-<a href="https://wzxsph.github.io/Narrative-Trace/"><img src="./assets/projects/narrative-flow.png" width="100%" alt="Narrative Trace 互动叙事循环" /></a>
-
-竖屏文字冒险与 AI 辅助创作管线。玩家观察、判断、行动，系统记住选择并生成结局画像。
-
-`Interactive Fiction`　`Agent Pipeline`　`Cloudflare`
-
-<a href="https://wzxsph.github.io/Narrative-Trace/"><img alt="Play Now" src="https://img.shields.io/badge/PLAY_NOW-开始游戏-D8FF3E?style=flat-square&labelColor=171717" /></a>
-
----
-
-### 05 · [Personality Escape Station](https://github.com/wzxsph/Personality-Escape-Station) ↗
-
-<p align="center">
-  <a href="https://personality-escape-station.samsong-1a3.workers.dev"><img src="./assets/projects/personality.jpg" width="46%" alt="人格出逃空间站真实首页" /></a>
-  &nbsp;
-  <a href="https://personality-escape-station.samsong-1a3.workers.dev"><img src="./assets/projects/personality-space.jpg" width="44%" alt="人格出逃空间站 BEDX 人格房间" /></a>
-</p>
-
-完成 10 道人格测试，生成身份卡，再进入一个可探索、可互动、可串门的竖屏像素空间。上图均来自项目真实运行页面。
-
-`React`　`Pixel World`　`AI Assets`　`Workers`
-
-<a href="https://personality-escape-station.samsong-1a3.workers.dev"><img alt="Live World" src="https://img.shields.io/badge/LIVE_WORLD-进入空间-D8FF3E?style=flat-square&labelColor=171717" /></a>
-
----
-
-### 06 · [AI 人生火锅](https://github.com/guanlili/ai-life-hotpot/tree/main) ↗
-
-<a href="https://ai-life-hotpot.guanhongli1921.workers.dev"><img src="./assets/projects/hotpot.png" width="100%" alt="AI 人生火锅体验首页" /></a>
-
-把人生选择隐喻成配火锅：拍照、选锅底、下食材、调蘸料，最后由 AI 生成专属人生报告。
-
-`TanStack Start`　`React 19`　`Multimodal AI`
-
-<a href="https://ai-life-hotpot.guanhongli1921.workers.dev"><img alt="Live Demo" src="https://img.shields.io/badge/LIVE_DEMO-煮一锅人生-D8FF3E?style=flat-square&labelColor=171717" /></a>
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="https://wzxsph.github.io/TT16/"><img src="./assets/projects/tt16.jpg" width="100%" alt="TT16 交易人格十六型" /></a>
+      <h3><a href="https://github.com/wzxsph/TT16">01 · TT16 交易人格十六型 ↗</a></h3>
+      <p>用 20 个真实决策情境，把交易偏好整理成 16 种可复盘的人格地图。完整报告在浏览器本地生成。</p>
+      <p><code>React 19</code> <code>TypeScript</code> <code>Vite</code> <code>Cloudflare</code></p>
+      <a href="https://wzxsph.github.io/TT16/"><img alt="Live Demo" src="https://img.shields.io/badge/LIVE_DEMO-打开体验-D8FF3E?style=flat-square&labelColor=171717" /></a>
+    </td>
+    <td width="50%" valign="top">
+      <a href="https://wzxsph.github.io/BadGuard/"><img src="./assets/projects/badguard.svg" width="100%" alt="BadGuard 散户看盘小纸条" /></a>
+      <h3><a href="https://github.com/wzxsph/BadGuard">02 · BadGuard 散户看盘小纸条 ↗</a></h3>
+      <p>每天收盘后，把 A 股常见技术状态整理成四张可解释的小纸条。只写观察与谨慎，不输出交易指令。</p>
+      <p><code>Cloudflare Workers</code> <code>Python</code> <code>AkShare</code></p>
+      <a href="https://wzxsph.github.io/BadGuard/"><img alt="Pages Demo" src="https://img.shields.io/badge/PAGES_DEMO-静态体验-D8FF3E?style=flat-square&labelColor=171717" /></a>
+      <a href="https://badguard.nizabentley397.workers.dev"><img alt="Realtime" src="https://img.shields.io/badge/LIVE_DATA-实时版-FF5B35?style=flat-square&labelColor=171717" /></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="https://github.com/wzxsph/hip-22-annotation-tool"><img src="./assets/projects/hip22.png" width="100%" alt="Hip 24-Point Annotation Tool 工作区" /></a>
+      <h3><a href="https://github.com/wzxsph/hip-22-annotation-tool">03 · Hip 24-Point Annotation Tool ↗</a></h3>
+      <p>面向髋关节 X 光片的本地标注与复核工具，支持 DICOM、YOLO 辅助初始化、24 个关键点和进度管理。</p>
+      <p><code>FastAPI</code> <code>Canvas</code> <code>YOLO</code> <code>DICOM</code></p>
+      <img alt="Source Only" src="https://img.shields.io/badge/SOURCE_ONLY-本地研究工具-F4F1E8?style=flat-square&labelColor=171717" />
+    </td>
+    <td width="50%" valign="top">
+      <a href="https://wzxsph.github.io/Narrative-Trace/"><img src="./assets/projects/narrative-flow.png" width="100%" alt="Narrative Trace 互动叙事循环" /></a>
+      <h3><a href="https://github.com/wzxsph/Narrative-Trace">04 · Narrative Trace ↗</a></h3>
+      <p>竖屏文字冒险与 AI 辅助创作管线。玩家观察、判断、行动，系统记住选择并生成结局画像。</p>
+      <p><code>Interactive Fiction</code> <code>Agent Pipeline</code> <code>Cloudflare</code></p>
+      <a href="https://wzxsph.github.io/Narrative-Trace/"><img alt="Play Now" src="https://img.shields.io/badge/PLAY_NOW-开始游戏-D8FF3E?style=flat-square&labelColor=171717" /></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="https://personality-escape-station.samsong-1a3.workers.dev"><img src="./assets/projects/personality.jpg" width="100%" alt="人格出逃空间站真实首页" /></a>
+      <h3><a href="https://github.com/wzxsph/Personality-Escape-Station">05 · Personality Escape Station ↗</a></h3>
+      <p>完成 10 道人格测试，生成身份卡，再进入一个可探索、可互动、可串门的竖屏像素空间。</p>
+      <p><code>React</code> <code>Pixel World</code> <code>AI Assets</code> <code>Workers</code></p>
+      <a href="https://personality-escape-station.samsong-1a3.workers.dev"><img alt="Live World" src="https://img.shields.io/badge/LIVE_WORLD-进入空间-D8FF3E?style=flat-square&labelColor=171717" /></a>
+    </td>
+    <td width="50%" valign="top">
+      <a href="https://ai-life-hotpot.guanhongli1921.workers.dev"><img src="./assets/projects/hotpot.png" width="100%" alt="AI 人生火锅体验首页" /></a>
+      <h3><a href="https://github.com/guanlili/ai-life-hotpot/tree/main">06 · AI 人生火锅 ↗</a></h3>
+      <p>把人生选择隐喻成配火锅：拍照、选锅底、下食材、调蘸料，最后由 AI 生成专属人生报告。</p>
+      <p><code>TanStack Start</code> <code>React 19</code> <code>Multimodal AI</code></p>
+      <a href="https://ai-life-hotpot.guanhongli1921.workers.dev"><img alt="Live Demo" src="https://img.shields.io/badge/LIVE_DEMO-煮一锅人生-D8FF3E?style=flat-square&labelColor=171717" /></a>
+    </td>
+  </tr>
+</table>
 
 <br />
 
 ## How I Build · 我如何做产品
 
-1. **Make it playable** — 先做出一个可以亲手完成的最小体验。用户的动作和反馈，比概念图更早验证产品。
-2. **Make AI controllable** — 把生成、校验、审查、发布拆成清晰步骤，让 Agent 从偶尔惊喜变成稳定系统。
-3. **Ship the boundary** — 部署路径、数据口径、免责声明和失败模式，和功能本身一样属于完整产品。
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <h3>01 · Make it playable</h3>
+      <p>先做出一个可以亲手完成的最小体验。用户的动作和反馈，比概念图更早验证产品。</p>
+    </td>
+    <td width="33%" valign="top">
+      <h3>02 · Make AI controllable</h3>
+      <p>把生成、校验、审查、发布拆成清晰步骤，让 Agent 从偶尔惊喜变成稳定系统。</p>
+    </td>
+    <td width="33%" valign="top">
+      <h3>03 · Ship the boundary</h3>
+      <p>部署路径、数据口径、免责声明和失败模式，和功能本身一样属于完整产品。</p>
+    </td>
+  </tr>
+</table>
 
 ## Recognition · 一些回响
 


### PR DESCRIPTION
## What changed
- restore the public README to the previous table-based layout
- keep all previous README content and ordering unchanged
- replace only the Personality Escape Station image with the left-side real landing-page screenshot
- retain the separate GitHub Pages mobile CSS improvements from the previous change

## Validation
- compared against commit `ae3793c`: README differs by exactly one image line
- confirmed the README references only `assets/projects/personality.jpg` for Personality Escape Station
- GitHub Markdown API render completed successfully
- `git diff --check`