### PR TITLE
Support dual-domain portfolio builds

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,9 +2,12 @@ import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 
+const site = process.env.SITE_URL ?? "https://wzxsph.github.io";
+const base = process.env.BASE_PATH ?? "/wzxsph";
+
 export default defineConfig({
-  site: "https://wzxsph.github.io",
-  base: "/wzxsph",
+  site,
+  base,
   output: "static",
   trailingSlash: "always",
   integrations: [mdx(), sitemap()],

--- a/scripts/check-build.mjs
+++ b/scripts/check-build.mjs
@@ -3,7 +3,10 @@ import { join, relative } from "node:path";
 
 const root = new URL("../", import.meta.url).pathname;
 const dist = join(root, "dist");
-const base = "/wzxsph";
+const site = (process.env.SITE_URL ?? "https://wzxsph.github.io").replace(/\/$/, "");
+const configuredBase = process.env.BASE_PATH ?? "/wzxsph";
+const base = configuredBase === "/" ? "" : `/${configuredBase.replace(/^\/+|\/+$/g, "")}`;
+const absoluteUrl = (path) => `${site}${base}${path}`;
 const slugs = ["fashionai-studio", "tt16", "storyweaver"];
 const expectedPages = [
   "index.html",
@@ -36,8 +39,7 @@ for (const file of htmlFiles) {
   assert(/<html lang="(?:en|zh-CN)">/.test(html), `${name}: missing document language`);
   assert((html.match(/<h1[ >]/g) ?? []).length === 1, `${name}: expected exactly one h1`);
   assert(/<title>[^<]+<\/title>/.test(html), `${name}: missing title`);
-  assert(/rel="canonical" href="https:\/\/wzxsph\.github\.io\/wzxsph\//.test(html), `${name}: invalid canonical URL`);
-  assert(!/(?:href|src)="\/(?!wzxsph(?:\/|"))/.test(html), `${name}: found root-relative URL outside ${base}`);
+  assert(html.includes(`rel="canonical" href="${site}${base}/`), `${name}: invalid canonical URL`);
 
   for (const tag of html.match(/<img\b[^>]*>/g) ?? []) {
     assert(/alt="[^"]+"/.test(tag), `${name}: image is missing meaningful alt text`);
@@ -45,6 +47,9 @@ for (const file of htmlFiles) {
 
   for (const match of html.matchAll(/(?:href|src)="([^"]+)"/g)) {
     const url = match[1];
+    if (base && url.startsWith("/")) {
+      assert(url === base || url.startsWith(`${base}/`), `${name}: found root-relative URL outside ${base}`);
+    }
     if (!url.startsWith(`${base}/`)) continue;
     const clean = decodeURIComponent(url.slice(base.length).split(/[?#]/)[0]);
     const target = clean.endsWith("/") ? join(dist, clean, "index.html") : join(dist, clean);
@@ -56,8 +61,8 @@ const englishHome = readFileSync(join(dist, "index.html"), "utf8");
 const chineseHome = readFileSync(join(dist, "zh/index.html"), "utf8");
 assert((englishHome.match(/class="project-row /g) ?? []).length === 3, "English home must contain exactly three flagship rows");
 assert((chineseHome.match(/class="project-row /g) ?? []).length === 3, "Chinese home must contain exactly three flagship rows");
-assert(englishHome.includes('hreflang="zh-CN" href="https://wzxsph.github.io/wzxsph/zh/"'), "English home is missing Chinese alternate");
-assert(chineseHome.includes('hreflang="en" href="https://wzxsph.github.io/wzxsph/"'), "Chinese home is missing English alternate");
+assert(englishHome.includes(`hreflang="zh-CN" href="${absoluteUrl("/zh/")}"`), "English home is missing Chinese alternate");
+assert(chineseHome.includes(`hreflang="en" href="${absoluteUrl("/")}"`), "Chinese home is missing English alternate");
 
 for (const slug of slugs) {
   const en = readFileSync(join(dist, `work/${slug}/index.html`), "utf8");

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,7 +1,8 @@
 import type { APIRoute } from "astro";
+import { withBase } from "../data/site";
 
 export const GET: APIRoute = ({ site }) => {
-  const sitemap = new URL("/wzxsph/sitemap-index.xml", site);
+  const sitemap = new URL(withBase("/sitemap-index.xml"), site);
   return new Response(`User-agent: *\nAllow: /\n\nSitemap: ${sitemap}\n`, {
     headers: { "Content-Type": "text/plain; charset=utf-8" },
   });

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -2,7 +2,7 @@
 import { getCollection, render, type CollectionEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import CaseStudyPage from "../../components/CaseStudyPage.astro";
-import type { ProjectSlug } from "../../data/site";
+import { withBase, type ProjectSlug } from "../../data/site";
 
 export async function getStaticPaths() {
   const entries = await getCollection("cases", ({ data }) => data.lang === "en");
@@ -22,7 +22,7 @@ const jsonLd = {
   creator: { "@type": "Person", name: "Pinhao Song", url: "https://github.com/wzxsph" },
   dateCreated: data.year,
   inLanguage: "en",
-  url: new URL(`/wzxsph/work/${slug}/`, Astro.site).toString(),
+  url: new URL(withBase(`/work/${slug}/`), Astro.site).toString(),
 };
 ---
 

--- a/src/pages/zh/work/[slug].astro
+++ b/src/pages/zh/work/[slug].astro
@@ -2,7 +2,7 @@
 import { getCollection, render, type CollectionEntry } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import CaseStudyPage from "../../../components/CaseStudyPage.astro";
-import type { ProjectSlug } from "../../../data/site";
+import { withBase, type ProjectSlug } from "../../../data/site";
 
 export async function getStaticPaths() {
   const entries = await getCollection("cases", ({ data }) => data.lang === "zh");
@@ -22,7 +22,7 @@ const jsonLd = {
   creator: { "@type": "Person", name: "宋品豪", url: "https://github.com/wzxsph" },
   dateCreated: data.year,
   inLanguage: "zh-CN",
-  url: new URL(`/wzxsph/zh/work/${slug}/`, Astro.site).toString(),
+  url: new URL(withBase(`/zh/work/${slug}/`), Astro.site).toString(),
 };
 ---
 


### PR DESCRIPTION
## What changed

- parameterize the Astro `site` and `base` values with `SITE_URL` and `BASE_PATH`
- generate robots and case-study JSON-LD URLs from the active base path
- make build validation work for both GitHub Pages and root-domain output

## Why

The portfolio currently targets only `https://wzxsph.github.io/wzxsph/`. These changes let the same source build cleanly for `https://ilovezi.xin/` without breaking the existing GitHub Pages deployment.

## Validation

- `npm ci`
- `npm run validate`
- `SITE_URL=https://ilovezi.xin BASE_PATH=/ npm run validate`
- verified the root-domain output has no internal `/wzxsph` path regressions